### PR TITLE
Fix outdated CakePHP documentation link

### DIFF
--- a/docs/Contributing.md
+++ b/docs/Contributing.md
@@ -21,6 +21,6 @@ assert coding standards are met. You can either use this pre-build repo and the 
 # Additional Resources
 
 * [Coding standards guide (extending/overwriting the CakePHP ones)](https://github.com/php-fig-rectified/fig-rectified-standards/)
-* [CakePHP coding standards](http://book.cakephp.org/3.0/en/contributing/cakephp-coding-conventions.html)
+* [CakePHP coding standards](https://book.cakephp.org/5/en/contributing/cakephp-coding-conventions.html)
 * [General GitHub documentation](http://help.github.com/)
 * [GitHub pull request documentation](http://help.github.com/send-pull-requests/)


### PR DESCRIPTION
## Summary

- Update CakePHP 3.x documentation link to 5.x