### PR TITLE
Skip empty enclosures and use array_is_list for category lists

### DIFF
--- a/src/View/RssView.php
+++ b/src/View/RssView.php
@@ -269,7 +269,7 @@ class RssView extends SerializedView {
 						$attrib['@domain'] = $val['domain'];
 						$attrib['@'] = $val['content'] ?? $attrib['@domain'];
 						$val = $attrib;
-					} elseif (is_array($val) && !empty($val[0])) {
+					} elseif (is_array($val) && array_is_list($val)) {
 						$categories = [];
 						foreach ($val as $category) {
 							$attrib = [];
@@ -321,7 +321,12 @@ class RssView extends SerializedView {
 
 					break;
 				case 'enclosure':
-					if (isset($val['url']) && is_string($val['url']) && !str_contains($val['url'], '://')) {
+					if (!is_array($val) || !isset($val['url']) || !is_string($val['url']) || $val['url'] === '') {
+						unset($item[$key]);
+
+						continue 2;
+					}
+					if (!str_contains($val['url'], '://')) {
 						$realpath = realpath(WWW_ROOT . $val['url']);
 						$wwwRealPath = realpath(WWW_ROOT);
 
@@ -338,7 +343,7 @@ class RssView extends SerializedView {
 							}
 						}
 					}
-					$attrib['@url'] = Router::url($val['url'] ?? '', true);
+					$attrib['@url'] = Router::url($val['url'], true);
 					$attrib['@length'] = $val['length'] ?? '';
 					$attrib['@type'] = $val['type'] ?? '';
 					$val = $attrib;

--- a/tests/TestCase/View/RssViewTest.php
+++ b/tests/TestCase/View/RssViewTest.php
@@ -573,6 +573,88 @@ RSS;
 	}
 
 	/**
+	 * Empty/missing enclosure URL must not produce an `<enclosure>` element with
+	 * an empty `url` attribute (which is invalid per RSS 2.0).
+	 *
+	 * @return void
+	 */
+	public function testSerializeWithEnclosureMissingUrlIsSkipped() {
+		$Request = new ServerRequest();
+		$Response = new Response();
+
+		$data = [
+			'channel' => [
+				'title' => 'Channel title',
+				'link' => 'http://channel.example.org',
+			],
+			'items' => [
+				[
+					'title' => 'Missing url key',
+					'link' => ['controller' => 'Foo', 'action' => 'bar'],
+					'description' => 'No enclosure url at all',
+					'enclosure' => ['length' => 1, 'type' => 'video/wmv'],
+				],
+				[
+					'title' => 'Empty url string',
+					'link' => ['controller' => 'Foo', 'action' => 'bar'],
+					'description' => 'Enclosure url is empty',
+					'enclosure' => ['url' => '', 'length' => 1, 'type' => 'video/wmv'],
+				],
+				[
+					'title' => 'Non-string url',
+					'link' => ['controller' => 'Foo', 'action' => 'bar'],
+					'description' => 'Enclosure url is not a string',
+					'enclosure' => ['url' => null, 'length' => 1, 'type' => 'video/wmv'],
+				],
+			],
+		];
+		$viewVars = ['channel' => $data];
+		$View = new RssView($Request, $Response, null, ['viewVars' => $viewVars]);
+		$serialize = 'channel';
+		$View->setConfig(compact('serialize'));
+		$result = $View->render('');
+
+		$this->assertStringNotContainsString('<enclosure', $result);
+		$this->assertStringNotContainsString('enclosure url=""', $result);
+	}
+
+	/**
+	 * Category passed as a list of values whose first element is falsy
+	 * (`0`, `''`, `null`, `false`) must still render as multiple `<category>`
+	 * elements. Previously the `!empty($val[0])` guard misclassified such lists
+	 * and folded them into a single tag.
+	 *
+	 * @return void
+	 */
+	public function testSerializeWithCategoryListWithFalsyFirstElement() {
+		$Request = new ServerRequest();
+		$Response = new Response();
+
+		$data = [
+			'channel' => [
+				'title' => 'Channel title',
+				'link' => 'http://channel.example.org',
+			],
+			'items' => [
+				[
+					'title' => 'Title One',
+					'link' => ['controller' => 'Foo', 'action' => 'bar'],
+					'description' => 'Content one',
+					'category' => ['0', 'tech'],
+				],
+			],
+		];
+		$viewVars = ['channel' => $data];
+		$View = new RssView($Request, $Response, null, ['viewVars' => $viewVars]);
+		$serialize = 'channel';
+		$View->setConfig(compact('serialize'));
+		$result = $View->render('');
+
+		$this->assertStringContainsString('<category>0</category>', $result);
+		$this->assertStringContainsString('<category>tech</category>', $result);
+	}
+
+	/**
 	 * RssViewTest::testSerializeWithCustomTags()
 	 *
 	 * @return void


### PR DESCRIPTION
## Summary

Two small correctness fixes in `RssView` with regression tests.

- **Empty/missing enclosure URL no longer emits an invalid element.** Previously, an `enclosure` view-var without a `url` (or with an empty/non-string `url`) still produced `<enclosure url="" length="" type=""/>`, which is invalid per RSS 2.0. The branch now skips emission entirely when the URL is unusable. (`src/View/RssView.php:323`)
- **Category list detection uses `array_is_list()`.** The previous `!empty($val[0])` guard misclassified lists whose first element was falsy (`0`, `''`, `null`, `false`) and folded the array into a single `<category>` tag with the entire list as content. Switching to `array_is_list($val)` correctly identifies sequential arrays regardless of the first value. (`src/View/RssView.php:272`)
- **Two new tests** in `tests/TestCase/View/RssViewTest.php`:
  - `testSerializeWithEnclosureMissingUrlIsSkipped` covers all three skip paths (missing key, empty string, non-string).
  - `testSerializeWithCategoryListWithFalsyFirstElement` pins the falsy-first-element regression.