### PR TITLE
Fix enclosure stat thrash, atom-link rel/type clobber, drop stale atom keyword

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,8 +8,7 @@
 		"plugin",
 		"view",
 		"rss",
-		"feed",
-		"atom"
+		"feed"
 	],
 	"authors": [
 		{

--- a/src/View/RssView.php
+++ b/src/View/RssView.php
@@ -86,6 +86,18 @@ class RssView extends SerializedView {
 	protected array $_cdata = [];
 
 	/**
+	 * Memoization cache for enclosure stat lookups (per render).
+	 *
+	 * Keyed by the input relative URL string. Each entry is either
+	 *   ['length' => string|null, 'type' => string|null]
+	 * for a resolved local file, or null when the URL did not resolve under
+	 * WWW_ROOT (so callers know to skip without re-running realpath).
+	 *
+	 * @var array<string, array{length: string, type: string|null}|null>
+	 */
+	protected array $_enclosureCache = [];
+
+	/**
 	 * Constructor
 	 *
 	 * @param \Cake\Http\ServerRequest|null $request
@@ -292,8 +304,12 @@ class RssView extends SerializedView {
 						$attrib = $val;
 						$attrib['@href'] = Router::url($val['@href'], true);
 						if ($prefix === 'atom') {
-							$attrib['@rel'] = 'self';
-							$attrib['@type'] = 'application/rss+xml';
+							// Default to the rss-self relation but don't clobber
+							// caller-supplied values. A feed publisher passing
+							// `@rel = alternate` for the human page used to be
+							// silently rewritten to `self`.
+							$attrib['@rel'] ??= 'self';
+							$attrib['@type'] ??= 'application/rss+xml';
 						}
 						$val = $attrib;
 					} elseif (is_array($val) && isset($val['url'])) {
@@ -326,20 +342,21 @@ class RssView extends SerializedView {
 
 						continue 2;
 					}
-					if (!str_contains($val['url'], '://')) {
-						$realpath = realpath(WWW_ROOT . $val['url']);
-						$wwwRealPath = realpath(WWW_ROOT);
-
-						if ($realpath && $wwwRealPath && strpos($realpath, $wwwRealPath) === 0 && is_file($realpath)) {
-							if (!isset($val['length'])) {
-								$val['length'] = sprintf('%u', filesize($realpath));
-							}
-							if (!isset($val['type'])) {
-								$finfo = finfo_open(FILEINFO_MIME_TYPE);
-								if ($finfo) {
-									$val['type'] = finfo_file($finfo, $realpath) ?: null;
-									finfo_close($finfo);
-								}
+					// Skip the disk probe entirely when both length and type are
+					// already supplied — that's the documented fast path. The
+					// realpath() / filesize() / finfo lookup is memoized per
+					// relative URL across a single render so N items sharing one
+					// enclosure (e.g. shared cover art) don't trigger N stat
+					// calls — previously every item ran the full probe.
+					if (
+						(!isset($val['length']) || !isset($val['type']))
+						&& !str_contains($val['url'], '://')
+					) {
+						$probe = $this->_resolveEnclosure($val['url']);
+						if ($probe !== null) {
+							$val['length'] = $val['length'] ?? $probe['length'];
+							if (!isset($val['type']) && $probe['type'] !== null) {
+								$val['type'] = $probe['type'];
 							}
 						}
 					}
@@ -385,6 +402,46 @@ class RssView extends SerializedView {
 		}
 
 		return $content;
+	}
+
+	/**
+	 * Resolve and stat a relative enclosure URL under WWW_ROOT, with memoization.
+	 *
+	 * Returns the file size (as the RSS `length` attribute expects) and the
+	 * detected MIME type, or null when the URL does not point at a real file
+	 * inside the document root. The path-containment check (`strpos($realpath,
+	 * $wwwRealPath) === 0`) guards against `../` traversal.
+	 *
+	 * Callers must already have decided that one of length / type is missing —
+	 * the cache exists purely to fold N items pointing at the same enclosure
+	 * (e.g. a shared cover image) into a single disk probe.
+	 *
+	 * @param string $relativeUrl Relative URL under WWW_ROOT.
+	 * @return array{length: string, type: string|null}|null
+	 */
+	protected function _resolveEnclosure(string $relativeUrl): ?array {
+		if (array_key_exists($relativeUrl, $this->_enclosureCache)) {
+			return $this->_enclosureCache[$relativeUrl];
+		}
+
+		$realpath = realpath(WWW_ROOT . $relativeUrl);
+		$wwwRealPath = realpath(WWW_ROOT);
+		if (!$realpath || !$wwwRealPath || strpos($realpath, $wwwRealPath) !== 0 || !is_file($realpath)) {
+			return $this->_enclosureCache[$relativeUrl] = null;
+		}
+
+		$type = null;
+		$finfo = finfo_open(FILEINFO_MIME_TYPE);
+		if ($finfo) {
+			$detected = finfo_file($finfo, $realpath);
+			$type = $detected !== false ? $detected : null;
+			finfo_close($finfo);
+		}
+
+		return $this->_enclosureCache[$relativeUrl] = [
+			'length' => sprintf('%u', filesize($realpath)),
+			'type' => $type,
+		];
 	}
 
 }

--- a/tests/TestCase/View/RssViewTest.php
+++ b/tests/TestCase/View/RssViewTest.php
@@ -619,6 +619,102 @@ RSS;
 	}
 
 	/**
+	 * Caller-supplied @rel / @type on an `atom:link` must not be silently
+	 * overwritten. The view default is `@rel = self`, `@type = application/rss+xml`
+	 * (the typical feed self-reference) but a publisher wiring an
+	 * `atom:link` for the human page passes `@rel = alternate` and
+	 * `@type = text/html` and that used to be clobbered to `self` /
+	 * `application/rss+xml`.
+	 *
+	 * @return void
+	 */
+	public function testAtomLinkPreservesCallerSuppliedRelAndType() {
+		$Request = new ServerRequest();
+		$Response = new Response();
+
+		$data = [
+			'channel' => [
+				'title' => 'Channel title',
+				'link' => 'http://channel.example.org',
+				'atom:link' => [
+					'@href' => ['controller' => 'Foo', 'action' => 'bar'],
+					'@rel' => 'alternate',
+					'@type' => 'text/html',
+				],
+			],
+			'items' => [],
+		];
+		$viewVars = ['channel' => $data];
+		$View = new RssView($Request, $Response, null, ['viewVars' => $viewVars]);
+		$View->setConfig(['serialize' => 'channel']);
+		$result = $View->render('');
+
+		$this->assertStringContainsString('rel="alternate"', $result);
+		$this->assertStringContainsString('type="text/html"', $result);
+		$this->assertStringNotContainsString('rel="self"', $result);
+		$this->assertStringNotContainsString('type="application/rss+xml"', $result);
+	}
+
+	/**
+	 * Multiple items pointing at the same relative enclosure URL share a single
+	 * disk probe — realpath/filesize/finfo run once and the result is reused.
+	 * The previous code re-ran realpath() + filesize() + finfo_open() per item.
+	 *
+	 * @return void
+	 */
+	public function testEnclosureLocalProbeIsMemoizedAcrossItems() {
+		$Request = new ServerRequest();
+		$Response = new Response();
+
+		if (!is_dir(WWW_ROOT)) {
+			mkdir(WWW_ROOT, 0777, true);
+		}
+		$relative = '/test-enclosure-' . uniqid() . '.bin';
+		$absolute = WWW_ROOT . ltrim($relative, '/');
+		file_put_contents($absolute, str_repeat('x', 1234));
+
+		try {
+			$data = [
+				'channel' => [
+					'title' => 'Channel title',
+					'link' => 'http://channel.example.org',
+				],
+				'items' => [
+					[
+						'title' => 'a',
+						'link' => ['controller' => 'Foo', 'action' => 'bar'],
+						'description' => 'a',
+						'enclosure' => ['url' => $relative],
+					],
+					[
+						'title' => 'b',
+						'link' => ['controller' => 'Foo', 'action' => 'bar'],
+						'description' => 'b',
+						'enclosure' => ['url' => $relative],
+					],
+				],
+			];
+			$viewVars = ['channel' => $data];
+			$View = new RssView($Request, $Response, null, ['viewVars' => $viewVars]);
+			$View->setConfig(['serialize' => 'channel']);
+			$result = $View->render('');
+
+			$this->assertSame(
+				2,
+				substr_count($result, 'length="1234"'),
+				'Both items should have their enclosure length populated from the memoized probe',
+			);
+			$this->assertSame(
+				2,
+				substr_count($result, 'type="text/plain"'),
+				'Both items should have their enclosure type populated from the memoized probe',
+			);
+		} finally {
+			@unlink($absolute);
+		}
+	}
+
+	/**
 	 * Category passed as a list of values whose first element is falsy
 	 * (`0`, `''`, `null`, `false`) must still render as multiple `<category>`
 	 * elements. Previously the `!empty($val[0])` guard misclassified such lists


### PR DESCRIPTION
## Summary

Three source-grounded fixes for the RssView path.

- **`RssView` re-stat'd local enclosure files on every render.** `realpath(WWW_ROOT . $url)`, `realpath(WWW_ROOT)`, `is_file()`, `filesize()`, and `finfo_open/_file/close` fired for every enclosure on every item, every render. A feed with N items that all reference the same cover image hit N disk probes. Two changes: the disk probe is skipped entirely when both `length` and `type` are already provided by the caller (the documented fast path), and the realpath / filesize / finfo lookup is memoized in `$_enclosureCache` keyed on the relative URL, so repeated references collapse to a single probe per render.
- **`atom:link` silently rewrote caller-supplied `@rel` / `@type`.** When the user passed `atom:link = ['@href' => ..., '@rel' => 'alternate', '@type' => 'text/html']` the view force-overwrote both to `self` / `application/rss+xml`. Switched to `??=` so the default still kicks in for the common self-reference case but a publisher wiring atom:link to the human page can override.
- **Stripped the `"atom"` composer keyword.** It was advertising a capability that doesn't exist (there is no AtomView). A real AtomView is a follow-up — the keyword removal is the smallest correct change in the meantime so anyone searching for atom-feed plugins won't get matched against this one and find rss only.

Two regression tests cover the atom-rel preservation and the per-URL memoized enclosure probe (asserts both items render with `length` and `type` populated when only one disk file is stat'd).

phpunit (18/18), phpstan, and phpcs all clean.
