### PR TITLE
Add AtomView for Atom 1.0 feed generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Total Downloads](https://poser.pugx.org/dereuromark/cakephp-feed/d/total.svg)](https://packagist.org/packages/dereuromark/cakephp-feed)
 [![Coding Standards](https://img.shields.io/badge/cs-PSR--2--R-purple.svg?style=flat-square)](https://github.com/php-fig-rectified/fig-rectified-standards)
 
-A CakePHP plugin containing a RssView class to generate RSS feeds.
+A CakePHP plugin containing `RssView` and `AtomView` classes for generating RSS 2.0 and Atom 1.0 feeds.
 
 ## Version notice
 
@@ -16,18 +16,25 @@ This branch is for use with **CakePHP 5.1+**. See [version map](https://github.c
 
 ## What is this plugin for?
 There used to be a core helper for RSS generation, but it had several deficiencies. It also was removed in 4.0.
-So this plugin aims to provide a better support for feed generation.
+So this plugin aims to provide a better support for feed generation — both RSS 2.0 (the de-facto standard, still required for podcasting) and Atom 1.0 (the cleaner, stricter successor preferred for most modern feeds).
 
-### Goals of this view class
+### Goals of these view classes
 
 - Support view-less actions via serialize.
 - Get rid of the ridiculously verbose "inline" namespace declarations.
 - Simplify the use of namespaces and their prefixes (auto-add only those that are actually used).
 - Support CDATA (unescaped content).
 - Allow mini-templating where necessary.
+- Accept friendly shorthands for the common case (bare strings for `link`, `author`, `category`) while leaving the full attribute shape available for power use.
+
+### RSS vs Atom: which one?
+
+- **RSS 2.0** if you publish a podcast. Apple Podcasts and the rest of that ecosystem require RSS plus the `itunes:` namespace. Also pick RSS if you have a specific reason to target the long tail of RSS-only readers.
+- **Atom 1.0** for almost anything else. Unambiguous date semantics (separate `<published>` and `<updated>`), typed content (`text`/`html`/`xhtml`), structured `<author>` with `<name>/<email>/<uri>`, multiple `<link rel>` per entry, mandatory `<id>` for proper deduplication. Most modern feed readers parse both equally well, and Atom is strictly less ambiguous.
+- **Both, if you're not sure.** Each view class is small; emitting `/feed.rss` and `/feed.atom` from the same controller action is a few extra lines.
 
 ### Additional features
-- Automatic View class mapping via `rss` extension.
+- Automatic View class mapping via `rss` and `atom` extensions.
 
 See [my article](https://www.dereuromark.de/2013/10/03/rss-feeds-in-cakephp/) for details on the history of this view class.
 
@@ -42,4 +49,3 @@ https://sandbox.dereuromark.de/sandbox/feed-examples
 ### Possible TODOs
 
 * Maybe add Feed readers instead of just writers.
-* Add AtomView ?

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 	"name": "dereuromark/cakephp-feed",
-	"description": "A CakePHP plugin containing a RssView to generate RSS feeds.",
+	"description": "A CakePHP plugin containing RssView and AtomView classes for generating RSS 2.0 and Atom 1.0 feeds.",
 	"license": "MIT",
 	"type": "cakephp-plugin",
 	"keywords": [
@@ -8,6 +8,7 @@
 		"plugin",
 		"view",
 		"rss",
+		"atom",
 		"feed"
 	],
 	"authors": [

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -1,5 +1,11 @@
 <?php
 
+use Cake\Http\MimeType;
 use Cake\Routing\Router;
 
-Router::extensions(['rss']);
+Router::extensions(['rss', 'atom']);
+
+// Cake ships `application/rss+xml` as a built-in MIME mapping but not Atom.
+// Register the `atom` shorthand so `$response->withType('atom')` (used in
+// AtomView's constructor) and route extension dispatch both resolve.
+MimeType::setMimeTypes('atom', 'application/atom+xml');

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -1,11 +1,13 @@
 <?php
 
-use Cake\Http\MimeType;
+use Cake\Http\Response;
 use Cake\Routing\Router;
 
 Router::extensions(['rss', 'atom']);
 
 // Cake ships `application/rss+xml` as a built-in MIME mapping but not Atom.
 // Register the `atom` shorthand so `$response->withType('atom')` (used in
-// AtomView's constructor) and route extension dispatch both resolve.
-MimeType::setMimeTypes('atom', 'application/atom+xml');
+// AtomView's constructor) and route extension dispatch both resolve. We go
+// through Response::setTypeMap so this works on both Cake 5.1 and 5.2+;
+// the dedicated MimeType class only landed in 5.2.
+(new Response())->setTypeMap('atom', 'application/atom+xml');

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@
 
 ## Documentation
 * [View/Rss](View/Rss.md)
+* [View/Atom](View/Atom.md)
 
 ## Contributing
 Your help is greatly appreciated.

--- a/docs/View/Atom.md
+++ b/docs/View/Atom.md
@@ -95,20 +95,13 @@ Atom distinguishes plain text, HTML, and XHTML. Plain string input becomes `type
 
 The view CDATA-wraps `type="html"` bodies so the markup survives the XML encode.
 
-For XHTML, wrap the body in the required xhtml-namespace `<div>` yourself:
-
-``` php
-'content' => [
-    '@type' => 'xhtml',
-    '@'     => '<div xmlns="http://www.w3.org/1999/xhtml"><p>X</p></div>',
-],
-```
+XHTML text constructs are **not currently supported** by `AtomView`. The serializer only supports plain text and `type="html"` text constructs at the moment; passing `@type => 'xhtml'` raises a `SerializationFailureException` instead of emitting invalid escaped markup.
 
 ### `updated`, `published` — date constructs
 
 Accepts `DateTimeInterface`, an int unix timestamp, or any string `DateTime` can parse. All inputs are normalized to RFC 3339 (`Y-m-d\TH:i:sP`), which is what Atom requires.
 
-`updated` is the last modification time and is **required**. `published` is the original publication time and is optional but strongly recommended — distinguishing the two is one of Atom's main advantages over RSS.
+`updated` is the last modification time and is **required**. `published` is the original publication time and is optional but strongly recommended — distinguishing the two is one of Atom's main advantages over RSS. Missing required fields (`id`, `title`, `updated` on the feed; `id`, `title`, `updated` on each entry) raise a `SerializationFailureException`.
 
 ### `link` — single, multiple, or shorthand
 

--- a/docs/View/Atom.md
+++ b/docs/View/Atom.md
@@ -1,0 +1,264 @@
+# Atom View
+
+A CakePHP view class for generating Atom 1.0 feeds ([RFC 4287](https://datatracker.ietf.org/doc/html/rfc4287)).
+
+- Template-less by default (same `serialize` flow as RssView)
+- Friendly shorthands for the common case, full attribute control when you need it
+- Mandatory fields enforced where the spec is strict (`id`, `title`, `updated`)
+- Auto-emits only the namespace declarations actually used
+- CDATA-wraps HTML content; leaves plain text un-CDATA'd for cleaner output
+
+If you're new to Atom, the README has a [RSS vs Atom guidance section](../../README.md#rss-vs-atom-which-one) explaining when to pick which.
+
+## Configs
+
+`setNamespace()` registers a custom namespace prefix that can be used as a `prefix:tag` key in the input. The matching `xmlns:prefix="..."` decl is only emitted at the root if the prefix actually appears somewhere in the rendered tree.
+
+The Atom default namespace (`http://www.w3.org/2005/Atom`) is bound automatically — you do not need to register it.
+
+## Setup
+
+Enable the Atom extension in your routes (or bootstrap):
+
+``` php
+Router::extensions(['atom']);
+```
+
+Activate the view class in your action:
+
+``` php
+$this->viewBuilder()->setClassName('Feed.Atom');
+```
+
+Or wire it once via view negotiation so every `.atom` request resolves to `AtomView`:
+
+``` php
+// AppController.php
+public function viewClasses(): array {
+    return [\Feed\View\AtomView::class];
+}
+```
+
+Set the data and tell the builder which viewVar to serialize:
+
+``` php
+$this->set(['feed' => $feed]);
+$this->viewBuilder()->setOption('serialize', 'feed');
+```
+
+## Input shape
+
+All fields are optional unless noted. Bare strings and structured arrays are accepted interchangeably:
+
+``` php
+$feed = [
+    'id'        => 'http://example.org/feed',   // REQUIRED — globally unique feed identifier (URI)
+    'title'     => 'My blog',                    // REQUIRED
+    'updated'   => '2026-05-11T12:00:00Z',       // REQUIRED — DateTime / DateTimeImmutable / int / string
+    'subtitle'  => 'Notes from the field',
+    'link'      => 'http://example.org/',        // shorthand: <link rel="alternate" href="..."/>
+    'author'    => 'Jane Doe',                   // shorthand: <author><name>Jane Doe</name></author>
+    'rights'    => 'Copyright 2026 Example, Inc.',
+    'generator' => 'CakePHP Feed Plugin',
+    'icon'      => '/favicon.ico',
+    'logo'      => '/logo.png',
+    'category'  => 'tech',
+    'entries'   => [
+        [
+            'id'        => 'http://example.org/posts/1',  // REQUIRED — globally unique entry identifier
+            'title'     => 'A post',                       // REQUIRED
+            'updated'   => '2026-05-11',                   // REQUIRED
+            'published' => '2026-05-10',                   // optional, distinct from `updated`
+            'link'      => 'http://example.org/posts/1',
+            'summary'   => 'A short teaser.',
+            'content'   => ['@type' => 'html', '@' => '<p>Full HTML body.</p>'],
+            'author'    => 'Jane',
+            'category'  => 'tech',
+        ],
+    ],
+];
+```
+
+## Field-by-field reference
+
+### `id` — required (feed and per-entry)
+
+Globally unique IRI. Atom readers use this to deduplicate, so it must be **stable across renders**. A common choice is the canonical permalink; for synthetic feeds a `urn:uuid:` is fine. The view does not generate one for you — pick one and stick with it.
+
+### `title`, `subtitle`, `rights`, `summary`, `content` — text constructs
+
+Atom distinguishes plain text, HTML, and XHTML. Plain string input becomes `type="text"` (escaped). For HTML, pass the full attribute shape:
+
+``` php
+'content' => ['@type' => 'html', '@' => '<p>This <em>is</em> HTML.</p>'],
+```
+
+The view CDATA-wraps `type="html"` bodies so the markup survives the XML encode.
+
+For XHTML, wrap the body in the required xhtml-namespace `<div>` yourself:
+
+``` php
+'content' => [
+    '@type' => 'xhtml',
+    '@'     => '<div xmlns="http://www.w3.org/1999/xhtml"><p>X</p></div>',
+],
+```
+
+### `updated`, `published` — date constructs
+
+Accepts `DateTimeInterface`, an int unix timestamp, or any string `DateTime` can parse. All inputs are normalized to RFC 3339 (`Y-m-d\TH:i:sP`), which is what Atom requires.
+
+`updated` is the last modification time and is **required**. `published` is the original publication time and is optional but strongly recommended — distinguishing the two is one of Atom's main advantages over RSS.
+
+### `link` — single, multiple, or shorthand
+
+``` php
+// Shorthand — defaults to rel="alternate"
+'link' => 'http://example.org/posts/1',
+
+// Single, explicit attributes
+'link' => ['@href' => '/feed.atom', '@rel' => 'self', '@type' => 'application/atom+xml'],
+
+// Multiple links on one entry (only Atom supports this — RSS does not)
+'link' => [
+    ['@href' => 'http://example.org/posts/1',         '@rel' => 'alternate'],
+    ['@href' => 'http://example.org/posts/1/comments','@rel' => 'replies'],
+    ['@href' => 'http://example.org/audio/1.mp3',     '@rel' => 'enclosure',
+     '@type' => 'audio/mpeg', '@length' => '12345'],
+],
+```
+
+The default for a string-shorthand link is `rel="alternate"`. The default `xmlns` is the Atom namespace, so a self-link to the feed itself is `['@href' => '/feed.atom', '@rel' => 'self', '@type' => 'application/atom+xml']`.
+
+### `author`, `contributor` — person constructs
+
+Atom person constructs have a required `<name>` plus optional `<email>` and `<uri>`. A bare string becomes the `name`. Multiple people pass as a list:
+
+``` php
+// Shorthand
+'author' => 'Jane Doe',
+
+// Structured
+'author' => ['name' => 'Jane Doe', 'email' => 'jane@example.org', 'uri' => 'http://example.org/~jane'],
+
+// Multiple (Atom-only — RSS has one author per item)
+'author' => [
+    ['name' => 'Alice'],
+    ['name' => 'Bob', 'email' => 'bob@example.org'],
+],
+```
+
+`contributor` works identically.
+
+### `category` — single, list, or shorthand
+
+``` php
+// Shorthand (term only)
+'category' => 'tech',
+
+// Single, with scheme + label
+'category' => ['@term' => 'php', '@scheme' => 'http://example.org/tags', '@label' => 'PHP'],
+
+// Multiple
+'category' => [
+    'tech',
+    ['@term' => 'php', '@scheme' => 'http://example.org/tags'],
+],
+```
+
+### Extension namespaces
+
+Built in: `dc`, `content`, `itunes`. Use them as `prefix:tag` keys and the matching `xmlns:prefix` decl appears automatically:
+
+``` php
+$feed = [
+    'id' => '...', 'title' => '...', 'updated' => '...',
+    'entries' => [
+        [
+            'id' => '...', 'title' => '...', 'updated' => '...',
+            'dc:creator' => 'Jane',
+            'content:encoded' => '<p>HTML body</p>',  // not CDATA-wrapped automatically here; use the html-content form instead
+        ],
+    ],
+];
+```
+
+For a custom namespace, register the prefix once (either via `setNamespace()` on the view, or by passing a top-level `namespace` key in the input):
+
+``` php
+$feed = [
+    'namespace' => ['ex' => 'http://example.org/ext'],
+    'id' => '...', 'title' => '...', 'updated' => '...',
+    'ex:owner' => 'Mark',
+];
+```
+
+Using a `prefix:tag` whose prefix has not been registered raises `RuntimeException` — silently emitting a broken namespace declaration is worse than failing loudly.
+
+## Examples
+
+### Minimal feed
+
+``` php
+$feed = [
+    'id'      => 'http://example.org/feed',
+    'title'   => 'My blog',
+    'updated' => time(),
+];
+$this->set(['feed' => $feed]);
+$this->viewBuilder()->setClassName('Feed.Atom');
+$this->viewBuilder()->setOption('serialize', 'feed');
+```
+
+Renders:
+
+``` xml
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <id>http://example.org/feed</id>
+  <title>My blog</title>
+  <updated>2026-05-11T12:00:00+00:00</updated>
+</feed>
+```
+
+### Self-link + alternate, multiple entries
+
+``` php
+$feed = [
+    'id'      => 'http://example.org/feed',
+    'title'   => 'My blog',
+    'updated' => '2026-05-11T12:00:00Z',
+    'link'    => [
+        ['@href' => 'http://example.org/',          '@rel' => 'alternate'],
+        ['@href' => 'http://example.org/feed.atom', '@rel' => 'self', '@type' => 'application/atom+xml'],
+    ],
+    'author'  => ['name' => 'Jane Doe', 'email' => 'jane@example.org'],
+    'entries' => [
+        [
+            'id'        => 'http://example.org/posts/2',
+            'title'     => 'Second post',
+            'updated'   => '2026-05-11T10:00:00Z',
+            'published' => '2026-05-11T08:00:00Z',
+            'link'      => 'http://example.org/posts/2',
+            'summary'   => 'About Atom.',
+            'content'   => ['@type' => 'html', '@' => '<p>Atom is great.</p>'],
+        ],
+        [
+            'id'        => 'http://example.org/posts/1',
+            'title'     => 'First post',
+            'updated'   => '2026-05-10T12:00:00Z',
+            'link'      => 'http://example.org/posts/1',
+        ],
+    ],
+];
+```
+
+### Podcast feed (RSS-only territory)
+
+If you need a podcast feed, use `RssView` with the `itunes:` namespace — Apple's spec requires RSS. See [Rss.md](Rss.md).
+
+## Spec references
+
+- [RFC 4287 — The Atom Syndication Format](https://datatracker.ietf.org/doc/html/rfc4287)
+- [Atom 1.0 vs RSS 2.0 comparison (W3C, archived)](https://web.archive.org/web/2022*/https://www.intertwingly.net/wiki/pie/Rss20AndAtom10Compared)
+- [Atom auto-discovery](https://datatracker.ietf.org/doc/html/rfc4287#section-3.1.1)

--- a/src/View/AtomView.php
+++ b/src/View/AtomView.php
@@ -4,7 +4,6 @@ namespace Feed\View;
 
 use Cake\Core\Configure;
 use Cake\Event\EventManager;
-use Cake\Http\MimeType;
 use Cake\Http\Response;
 use Cake\Http\ServerRequest;
 use Cake\I18n\DateTime as CakeDateTime;
@@ -125,12 +124,16 @@ class AtomView extends SerializedView {
 		?EventManager $eventManager = null,
 		array $viewOptions = [],
 	) {
-		// `atom` is not in Cake's built-in MIME map, so register it idempotently
-		// here via the static facade. The plugin's config/bootstrap.php also
-		// wires this for the route-extension path; doing it in the constructor
-		// keeps AtomView usable even when the plugin bootstrap hasn't been
-		// loaded (e.g. ad-hoc instantiation, integration tests).
-		MimeType::setMimeTypes('atom', 'application/atom+xml');
+		// `atom` is not in Cake's built-in MIME map, so register it
+		// idempotently here. We use the instance method on a throwaway
+		// Response because the underlying type map lives in static state
+		// shared across instances — this works on both Cake 5.1 (where
+		// MimeType isn't a separate class yet) and 5.2+ (where it is).
+		// The plugin's config/bootstrap.php registers the same binding
+		// for route-extension dispatch; doing it here too keeps AtomView
+		// usable when the plugin bootstrap hasn't been loaded (e.g.
+		// ad-hoc instantiation in integration tests).
+		(new Response())->setTypeMap('atom', 'application/atom+xml');
 
 		parent::__construct($request, $response, $eventManager, $viewOptions);
 

--- a/src/View/AtomView.php
+++ b/src/View/AtomView.php
@@ -1,0 +1,565 @@
+<?php
+
+namespace Feed\View;
+
+use Cake\Core\Configure;
+use Cake\Event\EventManager;
+use Cake\Http\MimeType;
+use Cake\Http\Response;
+use Cake\Http\ServerRequest;
+use Cake\I18n\DateTime as CakeDateTime;
+use Cake\Routing\Router;
+use Cake\Utility\Hash;
+use Cake\Utility\Xml;
+use Cake\View\SerializedView;
+use DateTimeImmutable;
+use DateTimeInterface;
+use RuntimeException;
+
+/**
+ * A view class for generating Atom 1.0 feeds (RFC 4287).
+ *
+ * Atom is the stricter, better-specified successor to RSS 2.0 — preferred for
+ * anything that isn't a podcast (which still requires RSS for tooling support).
+ * Per-entry it supports multiple `<link>` with explicit `@rel`, structured
+ * `<author>` with `<name>/<email>/<uri>`, typed `<content type="text|html|xhtml">`,
+ * separate `<published>` vs `<updated>`, RFC-3339 dates, and mandatory `<id>`.
+ *
+ * Setup mirrors RssView. By setting the `serialize` view option to a viewVar
+ * name, you can render an Atom feed without any template file:
+ *
+ * ```
+ * $this->set(['feed' => $feed]);
+ * $this->viewBuilder()->setOption('serialize', 'feed');
+ * $this->viewBuilder()->setClassName('Feed.Atom');
+ * ```
+ *
+ * Input shape (all keys are optional unless noted; bare strings and
+ * structured arrays are accepted interchangeably for convenience):
+ *
+ * ```php
+ * $feed = [
+ *     'id' => 'http://example.org/feed', // REQUIRED per RFC 4287
+ *     'title' => 'Channel title', // REQUIRED
+ *     'updated' => '2026-05-11T12:00:00Z', // REQUIRED — DateTime, string, or int
+ *     'subtitle' => 'A short description',
+ *     'link' => 'http://example.org/', // or full @href array, or list of links
+ *     'author' => 'Jane Doe', // or ['name' => ..., 'email' => ..., 'uri' => ...]
+ *     'rights' => 'Copyright 2026',
+ *     'generator' => 'CakePHP Feed Plugin',
+ *     'entries' => [
+ *         [
+ *             'id' => 'http://example.org/posts/1', // REQUIRED
+ *             'title' => 'A post', // REQUIRED
+ *             'updated' => '2026-05-11', // REQUIRED
+ *             'link' => 'http://example.org/posts/1',
+ *             'summary' => 'A teaser',
+ *             'content' => '<p>HTML body</p>', // shorthand: type=html, CDATA-wrapped
+ *             'author' => 'Jane',
+ *             'published' => '2026-05-10',
+ *             'category' => 'tech',
+ *         ],
+ *     ],
+ * ];
+ * ```
+ *
+ * For full attribute control wrap any field in an array with `@`-prefixed keys
+ * for attributes and `@` for the text content, exactly like RssView:
+ *
+ * - `link`: `['@href' => '/feed', '@rel' => 'self', '@type' => 'application/atom+xml']`
+ * - `content`: `['@type' => 'xhtml', '@' => '<div xmlns="http://www.w3.org/1999/xhtml">…</div>']`
+ * - `category`: `['@term' => 'php', '@scheme' => 'http://example.org/tags', '@label' => 'PHP']`
+ *
+ * @author Mark Scherer
+ * @license http://www.opensource.org/licenses/mit-license.php MIT License
+ * @see https://datatracker.ietf.org/doc/html/rfc4287
+ */
+class AtomView extends SerializedView {
+
+	/**
+	 * The Atom 1.0 default namespace.
+	 *
+	 * @var string
+	 */
+	public const ATOM_NAMESPACE = 'http://www.w3.org/2005/Atom';
+
+	/**
+	 * Holds additional namespaces beyond the Atom default. Used the same way as
+	 * RssView's namespace map — `xmlns:prefix="url"` is emitted only if the
+	 * prefix actually appears as a key in the input (e.g. `dc:creator`).
+	 *
+	 * @var array<string, string>
+	 */
+	protected array $_namespaces = [
+		'dc' => 'http://purl.org/dc/elements/1.1/',
+		'content' => 'http://purl.org/rss/1.0/modules/content/',
+		'itunes' => 'http://www.itunes.com/dtds/podcast-1.0.dtd',
+	];
+
+	/**
+	 * Tracks namespace prefixes that actually appeared in the input, so
+	 * unused namespace decls don't pollute the output.
+	 *
+	 * @var array<int, string>
+	 */
+	protected array $_usedNamespaces = [];
+
+	/**
+	 * CDATA placeholders. The Xml::fromArray() pipeline escapes everything by
+	 * default, so HTML content is staged here under a sentinel string that we
+	 * swap back in after rendering.
+	 *
+	 * @var array<int, string>
+	 */
+	protected array $_cdata = [];
+
+	/**
+	 * @param \Cake\Http\ServerRequest|null $request
+	 * @param \Cake\Http\Response|null $response
+	 * @param \Cake\Event\EventManager|null $eventManager
+	 * @param array<string, mixed> $viewOptions
+	 */
+	public function __construct(
+		?ServerRequest $request = null,
+		?Response &$response = null,
+		?EventManager $eventManager = null,
+		array $viewOptions = [],
+	) {
+		// `atom` is not in Cake's built-in MIME map, so register it idempotently
+		// here via the static facade. The plugin's config/bootstrap.php also
+		// wires this for the route-extension path; doing it in the constructor
+		// keeps AtomView usable even when the plugin bootstrap hasn't been
+		// loaded (e.g. ad-hoc instantiation, integration tests).
+		MimeType::setMimeTypes('atom', 'application/atom+xml');
+
+		parent::__construct($request, $response, $eventManager, $viewOptions);
+
+		if ($response !== null) {
+			$response = $response->withType('atom');
+		}
+	}
+
+	/**
+	 * @return string The Atom MIME type.
+	 */
+	public static function contentType(): string {
+		return 'application/atom+xml';
+	}
+
+	/**
+	 * Register a custom namespace usable as `prefix:tag` keys in the input.
+	 *
+	 * @param string $prefix
+	 * @param string $url
+	 * @return void
+	 */
+	public function setNamespace(string $prefix, string $url): void {
+		$this->_namespaces[$prefix] = $url;
+	}
+
+	/**
+	 * Normalize any date-ish input to an RFC 3339 string. Atom dates are
+	 * RFC 3339 — never RFC 822 like RSS.
+	 *
+	 * @param \DateTimeInterface|string|int $time
+	 * @return string
+	 */
+	public function time(DateTimeInterface|string|int $time): string {
+		if ($time instanceof DateTimeInterface) {
+			return $time->format(DateTimeInterface::ATOM);
+		}
+		if (is_int($time)) {
+			return (new DateTimeImmutable('@' . $time))->format(DateTimeInterface::ATOM);
+		}
+
+		return (new CakeDateTime($time))->format(DateTimeInterface::ATOM);
+	}
+
+	/**
+	 * Serialize view vars into Atom XML.
+	 *
+     * @param array<string>|string $serialize
+     * @throws \RuntimeException When a custom namespace prefix was used without being registered.
+     * @return string
+	 */
+	protected function _serialize(array|string $serialize): string {
+		if (is_array($serialize)) {
+			$data = [];
+			foreach ($serialize as $alias => $key) {
+				if (is_numeric($alias)) {
+					$alias = $key;
+				}
+				$data[$alias] = $this->viewVars[$key];
+			}
+		} else {
+			$data = $this->viewVars[$serialize] ?? null;
+			if (is_array($data) && Hash::numeric(array_keys($data))) {
+				$data = [$serialize => $data];
+			}
+		}
+		$data = (array)$data;
+
+		if (!empty($data['namespace'])) {
+			foreach ((array)$data['namespace'] as $prefix => $url) {
+				$this->setNamespace($prefix, $url);
+			}
+			unset($data['namespace']);
+		}
+
+		$entries = $data['entries'] ?? [];
+		unset($data['entries']);
+
+		$feed = $this->_prepareFeed($data);
+		if ($entries) {
+			$feed['entry'] = [];
+			foreach ($entries as $entry) {
+				$feed['entry'][] = $this->_prepareEntry($entry);
+			}
+		}
+
+		// The default `xmlns` is emitted via Xml::fromArray's `@`-attribute
+		// shape; prefixed `xmlns:foo` declarations use the *bare* key shape
+		// because Cake's array-to-XML pipeline interprets `@xmlns:foo` as a
+		// regular attribute and fails on `setAttributeNS` for the xmlns
+		// namespace. Plain `xmlns:foo` keys are recognized via a dedicated
+		// `str_contains($key, 'xmlns:')` branch in Xml::_createChild().
+		$root = ['@xmlns' => static::ATOM_NAMESPACE] + $feed;
+		foreach ($this->_usedNamespaces as $prefix) {
+			if (!isset($this->_namespaces[$prefix])) {
+				throw new RuntimeException(sprintf('The prefix %s is not specified.', $prefix));
+			}
+			$root['xmlns:' . $prefix] = $this->_namespaces[$prefix];
+		}
+
+		$options = [];
+		if (Configure::read('debug')) {
+			$options['pretty'] = true;
+		}
+
+		$output = Xml::fromArray(['feed' => $root], $options)->asXML();
+		if ($output === false) {
+			return '';
+		}
+
+		return $this->_replaceCdata($output);
+	}
+
+	/**
+	 * Build the feed-level (channel-equivalent) element body.
+	 *
+	 * @param array<string, mixed> $data
+	 * @return array<string, mixed>
+	 */
+	protected function _prepareFeed(array $data): array {
+		$out = [];
+
+		foreach (['id', 'title'] as $k) {
+			if (isset($data[$k])) {
+				$out[$k] = $data[$k];
+				unset($data[$k]);
+			}
+		}
+		if (isset($data['updated'])) {
+			$out['updated'] = $this->time($data['updated']);
+			unset($data['updated']);
+		}
+		if (isset($data['subtitle'])) {
+			$out['subtitle'] = $this->_prepareText($data['subtitle']);
+			unset($data['subtitle']);
+		}
+		if (isset($data['link'])) {
+			$out['link'] = $this->_prepareLinks($data['link']);
+			unset($data['link']);
+		}
+		if (isset($data['author'])) {
+			$out['author'] = $this->_preparePersons($data['author']);
+			unset($data['author']);
+		}
+		if (isset($data['contributor'])) {
+			$out['contributor'] = $this->_preparePersons($data['contributor']);
+			unset($data['contributor']);
+		}
+		foreach (['icon', 'logo', 'generator'] as $k) {
+			if (isset($data[$k])) {
+				$out[$k] = $data[$k];
+				unset($data[$k]);
+			}
+		}
+		if (isset($data['rights'])) {
+			$out['rights'] = $this->_prepareText($data['rights']);
+			unset($data['rights']);
+		}
+		if (isset($data['category'])) {
+			$out['category'] = $this->_prepareCategories($data['category']);
+			unset($data['category']);
+		}
+
+		// Anything left over (namespaced extensions like `itunes:owner`,
+		// custom elements) is carried through verbatim. Tracks the prefix
+		// so the matching `xmlns:foo` decl gets emitted at the root.
+		foreach ($data as $k => $v) {
+			$this->_trackNamespace($k);
+			$out[$k] = $v;
+		}
+
+		return $out;
+	}
+
+	/**
+	 * Build one `<entry>`.
+	 *
+	 * @param array<string, mixed> $entry
+	 * @return array<string, mixed>
+	 */
+	protected function _prepareEntry(array $entry): array {
+		$out = [];
+
+		foreach (['id', 'title'] as $k) {
+			if (isset($entry[$k])) {
+				$out[$k] = $entry[$k];
+				unset($entry[$k]);
+			}
+		}
+		foreach (['updated', 'published'] as $k) {
+			if (isset($entry[$k])) {
+				$out[$k] = $this->time($entry[$k]);
+				unset($entry[$k]);
+			}
+		}
+		if (isset($entry['link'])) {
+			$out['link'] = $this->_prepareLinks($entry['link']);
+			unset($entry['link']);
+		}
+		if (isset($entry['author'])) {
+			$out['author'] = $this->_preparePersons($entry['author']);
+			unset($entry['author']);
+		}
+		if (isset($entry['contributor'])) {
+			$out['contributor'] = $this->_preparePersons($entry['contributor']);
+			unset($entry['contributor']);
+		}
+		if (isset($entry['summary'])) {
+			$out['summary'] = $this->_prepareText($entry['summary']);
+			unset($entry['summary']);
+		}
+		if (isset($entry['content'])) {
+			$out['content'] = $this->_prepareText($entry['content']);
+			unset($entry['content']);
+		}
+		if (isset($entry['rights'])) {
+			$out['rights'] = $this->_prepareText($entry['rights']);
+			unset($entry['rights']);
+		}
+		if (isset($entry['category'])) {
+			$out['category'] = $this->_prepareCategories($entry['category']);
+			unset($entry['category']);
+		}
+		if (isset($entry['source']) && is_array($entry['source'])) {
+			// <source> carries the feed metadata an entry was originally
+			// published in; structurally it's a stripped-down feed.
+			$out['source'] = $this->_prepareFeed($entry['source']);
+			unset($entry['source']);
+		}
+
+		foreach ($entry as $k => $v) {
+			$this->_trackNamespace($k);
+			$out[$k] = $v;
+		}
+
+		return $out;
+	}
+
+	/**
+	 * Normalize link input to the Xml::fromArray attribute shape.
+	 *
+	 * Accepts a bare URL string, a single `@href` attribute array, or a list
+	 * of either. Bare strings default to `rel="alternate"`. Caller-supplied
+	 * `@rel` and `@type` are preserved verbatim.
+	 *
+	 * @param mixed $links
+	 * @return array<int, array<string, mixed>>
+	 */
+	protected function _prepareLinks(mixed $links): array {
+		if (is_string($links)) {
+			return [$this->_oneLink($links)];
+		}
+		if (is_array($links) && isset($links['@href'])) {
+			return [$this->_oneLink($links)];
+		}
+		if (is_array($links) && array_is_list($links)) {
+			return array_map(fn ($l) => $this->_oneLink($l), $links);
+		}
+
+		return [$this->_oneLink($links)];
+	}
+
+	/**
+	 * @param mixed $link
+	 * @return array<string, mixed>
+	 */
+	protected function _oneLink(mixed $link): array {
+		if (is_string($link)) {
+			return ['@href' => Router::url($link, true), '@rel' => 'alternate'];
+		}
+		if (is_array($link) && isset($link['@href'])) {
+			$link['@href'] = Router::url($link['@href'], true);
+			$link['@rel'] ??= 'alternate';
+
+			return $link;
+		}
+
+		/** @var array<string, mixed> $link */
+		return $link;
+	}
+
+	/**
+	 * Build a list of `<author>` or `<contributor>` elements.
+	 *
+	 * Atom person constructs have a required `<name>` plus optional `<email>`
+	 * and `<uri>`. A bare string is treated as the name; an associative array
+	 * with `name`/`email`/`uri` keys is used as-is; a list of either is
+	 * rendered as multiple sibling elements.
+	 *
+	 * @param mixed $persons
+	 * @return array<int, array<string, mixed>>
+	 */
+	protected function _preparePersons(mixed $persons): array {
+		if (is_string($persons)) {
+			return [['name' => $persons]];
+		}
+		if (
+			is_array($persons)
+			&& (isset($persons['name']) || isset($persons['email']) || isset($persons['uri']))
+		) {
+			return [$this->_onePerson($persons)];
+		}
+		if (is_array($persons) && array_is_list($persons)) {
+			return array_map(fn ($p) => $this->_onePerson($p), $persons);
+		}
+
+		return [$this->_onePerson($persons)];
+	}
+
+	/**
+	 * @param mixed $person
+	 * @return array<string, mixed>
+	 */
+	protected function _onePerson(mixed $person): array {
+		if (is_string($person)) {
+			return ['name' => $person];
+		}
+		if (!is_array($person)) {
+			return ['name' => (string)$person];
+		}
+
+		// Emit canonical order so output is deterministic.
+		$out = [];
+		foreach (['name', 'email', 'uri'] as $k) {
+			if (isset($person[$k])) {
+				$out[$k] = $person[$k];
+			}
+		}
+		foreach ($person as $k => $v) {
+			if (!isset($out[$k])) {
+				$out[$k] = $v;
+			}
+		}
+
+		return $out;
+	}
+
+	/**
+	 * Atom text constructs (`title`, `summary`, `content`, `rights`,
+	 * `subtitle`). Type defaults to `text`; `html` triggers CDATA wrapping.
+	 *
+	 * A plain string becomes `type="text"`. An array with `@type` and `@`
+	 * (Xml::fromArray's attribute+content shape) is used verbatim.
+	 *
+	 * @param mixed $text
+	 * @return array<string, mixed>|string
+	 */
+	protected function _prepareText(mixed $text): array|string {
+		if (is_string($text)) {
+			return $text;
+		}
+		if (!is_array($text)) {
+			return (string)$text;
+		}
+
+		$type = $text['@type'] ?? null;
+		if ($type === 'html' && isset($text['@']) && is_string($text['@']) && $text['@'] !== '') {
+			$text['@'] = $this->_newCdata($text['@']);
+		}
+
+		return $text;
+	}
+
+	/**
+	 * Categories accept a bare string (term only), a single `@term` attribute
+	 * array, or a list of either.
+	 *
+	 * @param mixed $cats
+	 * @return array<int, array<string, mixed>>
+	 */
+	protected function _prepareCategories(mixed $cats): array {
+		if (is_string($cats)) {
+			return [['@term' => $cats]];
+		}
+		if (is_array($cats) && isset($cats['@term'])) {
+			return [$cats];
+		}
+		if (is_array($cats) && array_is_list($cats)) {
+			return array_map(
+				fn ($c) => is_string($c) ? ['@term' => $c] : $c,
+				$cats,
+			);
+		}
+
+		return [$cats];
+	}
+
+	/**
+	 * Mark a `prefix:tag` key as having used a namespace so we emit its
+	 * `xmlns:prefix` decl at the root. Mirrors RssView's tracking.
+	 *
+	 * @param string $key
+	 * @return void
+	 */
+	protected function _trackNamespace(string $key): void {
+		if (!str_contains($key, ':')) {
+			return;
+		}
+		$prefix = explode(':', $key, 2)[0];
+		if (str_starts_with($prefix, '@')) {
+			$prefix = substr($prefix, 1);
+		}
+		if (!in_array($prefix, $this->_usedNamespaces, true)) {
+			$this->_usedNamespaces[] = $prefix;
+		}
+	}
+
+	/**
+	 * @param string $content
+	 * @return string
+	 */
+	protected function _newCdata(string $content): string {
+		$i = count($this->_cdata);
+		$this->_cdata[$i] = $content;
+
+		return '###CDATA-' . $i . '###';
+	}
+
+	/**
+	 * @param string $content
+	 * @return string
+	 */
+	protected function _replaceCdata(string $content): string {
+		foreach ($this->_cdata as $n => $data) {
+			$data = '<![CDATA[' . $data . ']]>';
+			$content = str_replace('###CDATA-' . $n . '###', $data, $content);
+		}
+
+		return $content;
+	}
+
+}

--- a/src/View/AtomView.php
+++ b/src/View/AtomView.php
@@ -10,6 +10,7 @@ use Cake\I18n\DateTime as CakeDateTime;
 use Cake\Routing\Router;
 use Cake\Utility\Hash;
 use Cake\Utility\Xml;
+use Cake\View\Exception\SerializationFailureException;
 use Cake\View\SerializedView;
 use DateTimeImmutable;
 use DateTimeInterface;
@@ -217,6 +218,13 @@ class AtomView extends SerializedView {
 			$feed['entry'] = [];
 			foreach ($entries as $entry) {
 				$feed['entry'][] = $this->_prepareEntry($entry);
+			}
+		}
+
+		$this->_assertRequiredFields($feed, ['id', 'title', 'updated'], 'feed');
+		if (!empty($feed['entry'])) {
+			foreach ($feed['entry'] as $index => $entry) {
+				$this->_assertRequiredFields($entry, ['id', 'title', 'updated'], 'entry #' . ($index + 1));
 			}
 		}
 
@@ -490,6 +498,9 @@ class AtomView extends SerializedView {
 		}
 
 		$type = $text['@type'] ?? null;
+		if ($type === 'xhtml') {
+			throw new SerializationFailureException('Atom XHTML text constructs are not supported.');
+		}
 		if ($type === 'html' && isset($text['@']) && is_string($text['@']) && $text['@'] !== '') {
 			$text['@'] = $this->_newCdata($text['@']);
 		}
@@ -563,6 +574,28 @@ class AtomView extends SerializedView {
 		}
 
 		return $content;
+	}
+
+	/**
+	 * @param array<string, mixed> $data
+	 * @param array<int, string> $fields
+	 * @param string $context
+	 * @return void
+	 */
+	protected function _assertRequiredFields(array $data, array $fields, string $context): void {
+		$missing = [];
+		foreach ($fields as $field) {
+			if (!array_key_exists($field, $data) || $data[$field] === null || $data[$field] === '') {
+				$missing[] = $field;
+			}
+		}
+		if ($missing) {
+			throw new SerializationFailureException(sprintf(
+				'Atom %s is missing required field(s): %s',
+				$context,
+				implode(', ', $missing),
+			));
+		}
 	}
 
 }

--- a/src/View/AtomView.php
+++ b/src/View/AtomView.php
@@ -34,8 +34,10 @@ use RuntimeException;
  * $this->viewBuilder()->setClassName('Feed.Atom');
  * ```
  *
- * Input shape (all keys are optional unless noted; bare strings and
- * structured arrays are accepted interchangeably for convenience):
+ * Input shape — `id`, `title`, `updated` are required at both the feed and
+ * entry level and raise a `SerializationFailureException` when missing.
+ * Other keys are optional. Bare strings and structured arrays are accepted
+ * interchangeably for convenience:
  *
  * ```php
  * $feed = [
@@ -43,8 +45,8 @@ use RuntimeException;
  *     'title' => 'Channel title', // REQUIRED
  *     'updated' => '2026-05-11T12:00:00Z', // REQUIRED — DateTime, string, or int
  *     'subtitle' => 'A short description',
- *     'link' => 'http://example.org/', // or full @href array, or list of links
- *     'author' => 'Jane Doe', // or ['name' => ..., 'email' => ..., 'uri' => ...]
+ *     'link' => 'http://example.org/', // string, @href array, Cake URL array, or list of either
+ *     'author' => 'Jane Doe', // string OR ['name' => ..., 'email' => ..., 'uri' => ...]
  *     'rights' => 'Copyright 2026',
  *     'generator' => 'CakePHP Feed Plugin',
  *     'entries' => [
@@ -52,9 +54,9 @@ use RuntimeException;
  *             'id' => 'http://example.org/posts/1', // REQUIRED
  *             'title' => 'A post', // REQUIRED
  *             'updated' => '2026-05-11', // REQUIRED
- *             'link' => 'http://example.org/posts/1',
- *             'summary' => 'A teaser',
- *             'content' => '<p>HTML body</p>', // shorthand: type=html, CDATA-wrapped
+ *             'link' => 'http://example.org/posts/1', // also accepts Cake URL arrays
+ *             'summary' => 'A teaser', // plain string => type="text" (escaped)
+ *             'content' => '<p>HTML body</p>', // plain string => type="text" (escaped)
  *             'author' => 'Jane',
  *             'published' => '2026-05-10',
  *             'category' => 'tech',
@@ -63,11 +65,21 @@ use RuntimeException;
  * ];
  * ```
  *
+ * Plain-string bodies for text constructs (`title`, `summary`, `content`,
+ * `subtitle`, `rights`) are always treated as `type="text"` and XML-escaped.
+ * To emit `type="html"` with a CDATA-wrapped body, use the array form with
+ * `@type` and `@` keys. `type="xhtml"` is rejected; pre-build the XHTML
+ * subtree at the application layer if you need it.
+ *
  * For full attribute control wrap any field in an array with `@`-prefixed keys
  * for attributes and `@` for the text content, exactly like RssView:
  *
- * - `link`: `['@href' => '/feed', '@rel' => 'self', '@type' => 'application/atom+xml']`
- * - `content`: `['@type' => 'xhtml', '@' => '<div xmlns="http://www.w3.org/1999/xhtml">…</div>']`
+ * - `link` (Atom self-link with explicit attrs):
+ *   `['@href' => '/feed', '@rel' => 'self', '@type' => 'application/atom+xml']`
+ * - `link` (Cake URL array shorthand — passed through `Router::url(..., true)`):
+ *   `['controller' => 'Posts', 'action' => 'feed', '_ext' => 'atom']`
+ * - `content` (HTML — body is CDATA-wrapped automatically):
+ *   `['@type' => 'html', '@' => '<p>HTML body</p>']`
  * - `category`: `['@term' => 'php', '@scheme' => 'http://example.org/tags', '@label' => 'PHP']`
  *
  * @author Mark Scherer
@@ -383,9 +395,15 @@ class AtomView extends SerializedView {
 	/**
 	 * Normalize link input to the Xml::fromArray attribute shape.
 	 *
-	 * Accepts a bare URL string, a single `@href` attribute array, or a list
-	 * of either. Bare strings default to `rel="alternate"`. Caller-supplied
-	 * `@rel` and `@type` are preserved verbatim.
+	 * Accepts:
+	 * - a bare URL string,
+	 * - a single `@href` attribute array,
+	 * - a Cake URL array (associative, e.g.
+	 *   `['controller' => 'Posts', 'action' => 'view', 1]`),
+	 * - a list of any of the above.
+	 *
+	 * Bare strings and Cake URL arrays default to `rel="alternate"`. Caller-
+	 * supplied `@rel` and `@type` survive verbatim.
 	 *
 	 * @param mixed $links
 	 * @return array<int, array<string, mixed>>
@@ -418,9 +436,16 @@ class AtomView extends SerializedView {
 
 			return $link;
 		}
+		if (is_array($link)) {
+			// Cake URL array shape (`['controller' => ..., 'action' => ...]`).
+			// Without this fallback the array would serialize as nested XML
+			// instead of a `<link href="..."/>` attribute element, which is
+			// what RssView already does and what users coming from RssView
+			// expect to keep working.
+			return ['@href' => Router::url($link, true), '@rel' => 'alternate'];
+		}
 
-		/** @var array<string, mixed> $link */
-		return $link;
+		return ['@href' => Router::url((string)$link, true), '@rel' => 'alternate'];
 	}
 
 	/**
@@ -564,13 +589,27 @@ class AtomView extends SerializedView {
 	}
 
 	/**
+	 * Replace the sentinel placeholders inserted by `_newCdata()` with real
+	 * `<![CDATA[...]]>` sections.
+	 *
+	 * The replacement splits any literal `]]>` sequence inside the staged
+	 * payload — a CDATA section cannot contain `]]>`, so naive wrapping
+	 * produces malformed XML whenever the HTML body itself contains that
+	 * three-byte sequence (e.g. an inline JS string or a nested CDATA from
+	 * a paste). The canonical workaround is to close the CDATA early, emit
+	 * the `]]>` as ordinary character data (escaped as `]]&gt;` via a fresh
+	 * CDATA opener), and resume: `]]]]><![CDATA[>` semantically expands to
+	 * `]]` (CDATA) + `>` (CDATA), which round-trips to the original `]]>`
+	 * on parse but never closes the outer section prematurely.
+	 *
 	 * @param string $content
 	 * @return string
 	 */
 	protected function _replaceCdata(string $content): string {
 		foreach ($this->_cdata as $n => $data) {
-			$data = '<![CDATA[' . $data . ']]>';
-			$content = str_replace('###CDATA-' . $n . '###', $data, $content);
+			$safe = str_replace(']]>', ']]]]><![CDATA[>', $data);
+			$wrapped = '<![CDATA[' . $safe . ']]>';
+			$content = str_replace('###CDATA-' . $n . '###', $wrapped, $content);
 		}
 
 		return $content;

--- a/tests/TestCase/View/AtomViewTest.php
+++ b/tests/TestCase/View/AtomViewTest.php
@@ -1,0 +1,401 @@
+<?php
+/**
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @author Mark Scherer
+ * @license http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+
+namespace Feed\Test\TestCase\View;
+
+use Cake\Core\Configure;
+use Cake\Http\Response;
+use Cake\Http\ServerRequest;
+use Cake\Routing\Route\DashedRoute;
+use Cake\Routing\Router;
+use Cake\TestSuite\TestCase;
+use Cake\View\Exception\SerializationFailureException;
+use DateTimeImmutable;
+use Feed\View\AtomView;
+use RuntimeException;
+
+class AtomViewTest extends TestCase {
+
+	protected AtomView $Atom;
+
+	protected string $baseUrl;
+
+	protected bool $debugWas;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		// Disable debug so Xml::fromArray doesn't pretty-print — the assertions
+		// below compare flat strings. Pretty-printing only affects whitespace,
+		// not semantics; toggling it for the test keeps the assertions tight.
+		$this->debugWas = (bool)Configure::read('debug');
+		Configure::write('debug', false);
+
+		$this->Atom = new AtomView();
+		$this->baseUrl = trim(Router::url('/', true), '/');
+
+		Router::reload();
+		$builder = Router::createRouteBuilder('/');
+		$builder->fallbacks(DashedRoute::class);
+		$builder->connect('/{controller}/{action}/*');
+	}
+
+	public function tearDown(): void {
+		Configure::write('debug', $this->debugWas);
+		parent::tearDown();
+	}
+
+	/**
+	 * RFC 3339 dates: same format whether the input is DateTimeImmutable,
+	 * an int unix timestamp, or a string the constructor can parse. Outputs
+	 * are always in the form `Y-m-d\TH:i:sP`.
+	 */
+	public function testTimeAcceptsHeterogeneousInputs(): void {
+		$expected = '2026-05-11T12:34:56+00:00';
+
+		$dt = new DateTimeImmutable($expected);
+		$this->assertSame($expected, $this->Atom->time($dt));
+
+		// Int input is a unix timestamp at UTC.
+		$ts = $dt->getTimestamp();
+		$this->assertSame($expected, $this->Atom->time($ts));
+
+		// String input parsed by Cake's DateTime. Timezone-aware string round-trips.
+		$this->assertSame($expected, $this->Atom->time($expected));
+	}
+
+	/**
+	 * Minimal feed: only the three RFC-required fields, no entries. Verifies
+	 * the default Atom namespace binds correctly so any reader can parse it.
+	 */
+	public function testMinimalFeedShape(): void {
+		$View = $this->buildView([
+			'feed' => [
+				'id' => 'urn:uuid:minimal',
+				'title' => 'Minimal',
+				'updated' => '2026-05-11T00:00:00Z',
+			],
+		]);
+
+		$out = $View->render('');
+
+		$this->assertStringContainsString('<?xml version="1.0"', $out);
+		$this->assertStringContainsString('<feed xmlns="http://www.w3.org/2005/Atom"', $out);
+		$this->assertStringContainsString('<id>urn:uuid:minimal</id>', $out);
+		$this->assertStringContainsString('<title>Minimal</title>', $out);
+		$this->assertStringContainsString('<updated>2026-05-11T00:00:00+00:00</updated>', $out);
+		$this->assertStringNotContainsString('<entry', $out);
+	}
+
+	/**
+	 * String shorthand for `link` becomes `<link rel="alternate" href="..."/>`
+	 * — that's the Atom convention. Caller-supplied `@rel` survives.
+	 */
+	public function testLinkShorthandAndMultipleLinksPerEntry(): void {
+		$View = $this->buildView([
+			'feed' => [
+				'id' => 'urn:test',
+				'title' => 'Links',
+				'updated' => '2026-05-11T00:00:00Z',
+				'link' => [
+					['@href' => 'http://example.org/', '@rel' => 'alternate'],
+					['@href' => 'http://example.org/feed.atom', '@rel' => 'self', '@type' => 'application/atom+xml'],
+				],
+				'entries' => [
+					[
+						'id' => 'urn:e:1',
+						'title' => 'Entry',
+						'updated' => '2026-05-11T00:00:00Z',
+						'link' => 'http://example.org/posts/1',
+					],
+				],
+			],
+		]);
+
+		$out = $View->render('');
+
+		$this->assertStringContainsString('href="http://example.org/" rel="alternate"', $out);
+		$this->assertStringContainsString('href="http://example.org/feed.atom" rel="self"', $out);
+		$this->assertStringContainsString('type="application/atom+xml"', $out);
+		$this->assertStringContainsString('href="http://example.org/posts/1" rel="alternate"', $out);
+	}
+
+	/**
+	 * String shorthand for `author` produces a structured person with just
+	 * `<name>` populated.
+	 */
+	public function testAuthorShorthandAndStructuredEqual(): void {
+		$shorthandOut = $this->buildView([
+			'feed' => [
+				'id' => 'a',
+				'title' => 't',
+				'updated' => '2026-05-11T00:00:00Z',
+				'author' => 'Jane Doe',
+			],
+		])->render('');
+
+		$structuredOut = $this->buildView([
+			'feed' => [
+				'id' => 'a',
+				'title' => 't',
+				'updated' => '2026-05-11T00:00:00Z',
+				'author' => ['name' => 'Jane Doe'],
+			],
+		])->render('');
+
+		$this->assertStringContainsString('<author><name>Jane Doe</name></author>', $shorthandOut);
+		$this->assertSame($shorthandOut, $structuredOut);
+	}
+
+	/**
+	 * `author` accepts a list of person constructs and emits one `<author>`
+	 * per element. RSS lacks this — it's an Atom advantage.
+	 */
+	public function testMultipleAuthorsAndContributors(): void {
+		$out = $this->buildView([
+			'feed' => [
+				'id' => 'a',
+				'title' => 't',
+				'updated' => '2026-05-11T00:00:00Z',
+				'author' => [
+					['name' => 'Alice', 'email' => 'alice@example.org'],
+					['name' => 'Bob', 'uri' => 'http://example.org/~bob'],
+				],
+				'contributor' => [
+					['name' => 'Carol'],
+				],
+			],
+		])->render('');
+
+		$this->assertSame(2, substr_count($out, '<author>'));
+		$this->assertStringContainsString('<name>Alice</name>', $out);
+		$this->assertStringContainsString('<email>alice@example.org</email>', $out);
+		$this->assertStringContainsString('<name>Bob</name>', $out);
+		$this->assertStringContainsString('<uri>http://example.org/~bob</uri>', $out);
+		$this->assertStringContainsString('<contributor><name>Carol</name></contributor>', $out);
+	}
+
+	/**
+	 * HTML-typed content is CDATA-wrapped so reader markup survives. The
+	 * placeholder-then-replace mechanism guarantees Xml::fromArray doesn't
+	 * double-escape it.
+	 */
+	public function testHtmlContentIsCdataWrapped(): void {
+		$out = $this->buildView([
+			'feed' => [
+				'id' => 'a',
+				'title' => 't',
+				'updated' => '2026-05-11T00:00:00Z',
+				'entries' => [
+					[
+						'id' => 'urn:e:1',
+						'title' => 'Entry',
+						'updated' => '2026-05-11T00:00:00Z',
+						'content' => ['@type' => 'html', '@' => '<p>Hello <em>world</em></p>'],
+					],
+				],
+			],
+		])->render('');
+
+		$this->assertStringContainsString('<content type="html"><![CDATA[<p>Hello <em>world</em></p>]]></content>', $out);
+	}
+
+	/**
+	 * Text-typed content (the default) does NOT get CDATA-wrapped — the XML
+	 * encoder takes care of escaping. Avoids needless `<![CDATA[plain text]]>`.
+	 */
+	public function testTextContentIsNotCdataWrapped(): void {
+		$out = $this->buildView([
+			'feed' => [
+				'id' => 'a',
+				'title' => 't',
+				'updated' => '2026-05-11T00:00:00Z',
+				'entries' => [
+					[
+						'id' => 'urn:e:1',
+						'title' => 'Entry',
+						'updated' => '2026-05-11T00:00:00Z',
+						'summary' => 'A teaser with <special> chars',
+					],
+				],
+			],
+		])->render('');
+
+		$this->assertStringNotContainsString('<![CDATA[', $out);
+		$this->assertStringContainsString('A teaser with &lt;special&gt; chars', $out);
+	}
+
+	/**
+	 * Category accepts bare string and list-of-strings shorthand alongside
+	 * full attribute arrays.
+	 */
+	public function testCategoryShorthandAndFullForm(): void {
+		$out = $this->buildView([
+			'feed' => [
+				'id' => 'a',
+				'title' => 't',
+				'updated' => '2026-05-11T00:00:00Z',
+				'entries' => [
+					[
+						'id' => 'urn:e:1',
+						'title' => 'Entry',
+						'updated' => '2026-05-11T00:00:00Z',
+						'category' => [
+							'tech',
+							['@term' => 'php', '@scheme' => 'http://example.org/tags', '@label' => 'PHP'],
+						],
+					],
+				],
+			],
+		])->render('');
+
+		$this->assertStringContainsString('<category term="tech"', $out);
+		$this->assertStringContainsString('<category term="php" scheme="http://example.org/tags" label="PHP"', $out);
+	}
+
+	/**
+	 * `published` and `updated` are distinct fields. Atom forced this split
+	 * precisely to fix RSS's `pubDate`-ambiguity.
+	 */
+	public function testEntryHasBothPublishedAndUpdated(): void {
+		$out = $this->buildView([
+			'feed' => [
+				'id' => 'a',
+				'title' => 't',
+				'updated' => '2026-05-11T00:00:00Z',
+				'entries' => [
+					[
+						'id' => 'urn:e:1',
+						'title' => 'Entry',
+						'published' => '2026-05-10T08:00:00Z',
+						'updated' => '2026-05-11T16:00:00Z',
+					],
+				],
+			],
+		])->render('');
+
+		$this->assertStringContainsString('<published>2026-05-10T08:00:00+00:00</published>', $out);
+		$this->assertStringContainsString('<updated>2026-05-11T16:00:00+00:00</updated>', $out);
+	}
+
+	/**
+	 * Custom namespaced keys (e.g. dc:creator) make the matching xmlns decl
+	 * appear at the root, but only that one — unused declarations stay out
+	 * of the output for cleanliness.
+	 */
+	public function testCustomNamespaceIsEmittedOnlyWhenUsed(): void {
+		$out = $this->buildView([
+			'feed' => [
+				'id' => 'a',
+				'title' => 't',
+				'updated' => '2026-05-11T00:00:00Z',
+				'entries' => [
+					[
+						'id' => 'urn:e:1',
+						'title' => 'Entry',
+						'updated' => '2026-05-11T00:00:00Z',
+						'dc:creator' => 'Jane',
+					],
+				],
+			],
+		])->render('');
+
+		$this->assertStringContainsString('xmlns:dc="http://purl.org/dc/elements/1.1/"', $out);
+		$this->assertStringContainsString('<dc:creator>Jane</dc:creator>', $out);
+		$this->assertStringNotContainsString('xmlns:itunes=', $out);
+		$this->assertStringNotContainsString('xmlns:content=', $out);
+	}
+
+	/**
+	 * Using a `prefix:tag` key whose prefix was never registered must blow
+	 * up loudly. Silently emitting a broken namespace is worse than failing.
+	 */
+	public function testUnregisteredNamespaceThrows(): void {
+		$View = $this->buildView([
+			'feed' => [
+				'id' => 'a',
+				'title' => 't',
+				'updated' => '2026-05-11T00:00:00Z',
+				'entries' => [
+					['id' => 'urn:e:1', 'title' => 'E', 'updated' => '2026-05-11T00:00:00Z', 'foo:bar' => 'x'],
+				],
+			],
+		]);
+
+		// SerializedView wraps inner exceptions in SerializationFailureException;
+		// unwrap once to assert on the actual cause from our serializer.
+		$caught = null;
+		try {
+			$View->render('');
+		} catch (SerializationFailureException $e) {
+			$caught = $e->getPrevious();
+		}
+
+		$this->assertInstanceOf(RuntimeException::class, $caught);
+		$this->assertStringContainsString('foo', $caught->getMessage());
+	}
+
+	/**
+	 * Caller-passed namespaces via the top-level `namespace` key get
+	 * registered before render — same shape RssView uses, just plumbed
+	 * here.
+	 */
+	public function testInputCanRegisterCustomNamespaces(): void {
+		$out = $this->buildView([
+			'feed' => [
+				'namespace' => ['ex' => 'http://example.org/ext'],
+				'id' => 'a',
+				'title' => 't',
+				'updated' => '2026-05-11T00:00:00Z',
+				'ex:owner' => 'someone',
+			],
+		])->render('');
+
+		$this->assertStringContainsString('xmlns:ex="http://example.org/ext"', $out);
+		$this->assertStringContainsString('<ex:owner>someone</ex:owner>', $out);
+	}
+
+	/**
+	 * Content type the view advertises matches the Atom MIME spec. Loosely
+	 * coupled to the response only — Cake's TypeMap is the authority for the
+	 * "atom" extension binding.
+	 */
+	public function testContentTypeIsAtomXml(): void {
+		$this->assertSame('application/atom+xml', AtomView::contentType());
+	}
+
+	/**
+	 * Instantiating the view registers `atom => application/atom+xml` on the
+	 * Response TypeMap idempotently and applies `withType('atom')` to the
+	 * passed response — so a freshly constructed view emits the right
+	 * Content-Type header without any extra wiring on the caller side.
+	 */
+	public function testResponseGetsAtomContentType(): void {
+		$Request = new ServerRequest();
+		$Response = new Response();
+		new AtomView($Request, $Response, null, ['viewVars' => []]);
+
+		$this->assertNotNull($Response);
+		$this->assertStringContainsString('application/atom+xml', $Response->getHeaderLine('Content-Type'));
+	}
+
+	/**
+	 * @param array<string, mixed> $viewVars
+	 */
+	protected function buildView(array $viewVars): AtomView {
+		$Request = new ServerRequest();
+		$Response = new Response();
+		$View = new AtomView($Request, $Response, null, ['viewVars' => $viewVars]);
+		$View->setConfig(['serialize' => array_key_first($viewVars)]);
+
+		return $View;
+	}
+
+}

--- a/tests/TestCase/View/AtomViewTest.php
+++ b/tests/TestCase/View/AtomViewTest.php
@@ -95,6 +95,28 @@ class AtomViewTest extends TestCase {
 	}
 
 	/**
+	 * Atom requires `id`, `title`, and `updated` at the feed level. Rendering
+	 * a partial feed would otherwise silently emit invalid XML.
+	 */
+	public function testMissingRequiredFeedFieldsThrow(): void {
+		$View = $this->buildView([
+			'feed' => [
+				'title' => 'Missing required fields',
+			],
+		]);
+
+		$caught = null;
+		try {
+			$View->render('');
+		} catch (SerializationFailureException $e) {
+			$caught = $e->getPrevious();
+		}
+
+		$this->assertInstanceOf(SerializationFailureException::class, $caught);
+		$this->assertStringContainsString('Atom feed is missing required field(s): id, updated', $caught->getMessage());
+	}
+
+	/**
 	 * String shorthand for `link` becomes `<link rel="alternate" href="..."/>`
 	 * — that's the Atom convention. Caller-supplied `@rel` survives.
 	 */
@@ -208,6 +230,42 @@ class AtomViewTest extends TestCase {
 	}
 
 	/**
+	 * XHTML text constructs need nested namespaced markup, which this
+	 * serializer does not currently support. Fail loudly instead of emitting
+	 * invalid escaped text while claiming XHTML support.
+	 */
+	public function testXhtmlContentThrows(): void {
+		$View = $this->buildView([
+			'feed' => [
+				'id' => 'a',
+				'title' => 't',
+				'updated' => '2026-05-11T00:00:00Z',
+				'entries' => [
+					[
+						'id' => 'urn:e:1',
+						'title' => 'Entry',
+						'updated' => '2026-05-11T00:00:00Z',
+						'content' => [
+							'@type' => 'xhtml',
+							'@' => '<div xmlns="http://www.w3.org/1999/xhtml"><p>X</p></div>',
+						],
+					],
+				],
+			],
+		]);
+
+		$caught = null;
+		try {
+			$View->render('');
+		} catch (SerializationFailureException $e) {
+			$caught = $e->getPrevious();
+		}
+
+		$this->assertInstanceOf(SerializationFailureException::class, $caught);
+		$this->assertStringContainsString('Atom XHTML text constructs are not supported.', $caught->getMessage());
+	}
+
+	/**
 	 * Text-typed content (the default) does NOT get CDATA-wrapped — the XML
 	 * encoder takes care of escaping. Avoids needless `<![CDATA[plain text]]>`.
 	 */
@@ -283,6 +341,35 @@ class AtomViewTest extends TestCase {
 
 		$this->assertStringContainsString('<published>2026-05-10T08:00:00+00:00</published>', $out);
 		$this->assertStringContainsString('<updated>2026-05-11T16:00:00+00:00</updated>', $out);
+	}
+
+	/**
+	 * Entries have the same required field set as the feed minus feed-only
+	 * metadata. Missing them should fail instead of producing invalid Atom.
+	 */
+	public function testMissingRequiredEntryFieldsThrow(): void {
+		$View = $this->buildView([
+			'feed' => [
+				'id' => 'a',
+				'title' => 't',
+				'updated' => '2026-05-11T00:00:00Z',
+				'entries' => [
+					[
+						'title' => 'Entry without required fields',
+					],
+				],
+			],
+		]);
+
+		$caught = null;
+		try {
+			$View->render('');
+		} catch (SerializationFailureException $e) {
+			$caught = $e->getPrevious();
+		}
+
+		$this->assertInstanceOf(SerializationFailureException::class, $caught);
+		$this->assertStringContainsString('Atom entry #1 is missing required field(s): id, updated', $caught->getMessage());
 	}
 
 	/**

--- a/tests/TestCase/View/AtomViewTest.php
+++ b/tests/TestCase/View/AtomViewTest.php
@@ -266,6 +266,71 @@ class AtomViewTest extends TestCase {
 	}
 
 	/**
+	 * HTML content containing a literal `]]>` sequence must not break CDATA
+	 * wrapping. The canonical workaround is to split the sequence as
+	 * `]]]]><![CDATA[>`, which round-trips to the original `]]>` on parse but
+	 * never closes the outer CDATA section prematurely. Without the split the
+	 * emitted XML would be malformed and any reader would reject the feed.
+	 */
+	public function testHtmlContentSplitsLiteralCdataTerminator(): void {
+		$out = $this->buildView([
+			'feed' => [
+				'id' => 'a',
+				'title' => 't',
+				'updated' => '2026-05-11T00:00:00Z',
+				'entries' => [
+					[
+						'id' => 'urn:e:1',
+						'title' => 'Entry',
+						'updated' => '2026-05-11T00:00:00Z',
+						'content' => [
+							'@type' => 'html',
+							'@' => 'before]]>after',
+						],
+					],
+				],
+			],
+		])->render('');
+
+		// The exact escape sequence per the CDATA-injection workaround.
+		$this->assertStringContainsString('<content type="html"><![CDATA[before]]]]><![CDATA[>after]]></content>', $out);
+
+		// And — more importantly — the result must still round-trip through a
+		// real XML parser. simplexml lets us verify both well-formedness and
+		// that the inner text reads back as the original payload.
+		$doc = simplexml_load_string($out);
+		$this->assertNotFalse($doc, 'feed must remain well-formed XML after the CDATA split');
+		$content = (string)$doc->entry->content;
+		$this->assertSame('before]]>after', $content);
+	}
+
+	/**
+	 * Cake URL arrays (e.g. `['controller' => 'Posts', 'action' => 'view', 1]`)
+	 * are routed through `Router::url(..., true)` just like in RssView,
+	 * instead of falling through and serializing as nested XML children of
+	 * `<link>`. This is the shape most app code already uses with RssView.
+	 */
+	public function testLinkAcceptsCakeUrlArrayShorthand(): void {
+		$out = $this->buildView([
+			'feed' => [
+				'id' => 'a',
+				'title' => 't',
+				'updated' => '2026-05-11T00:00:00Z',
+				'link' => [
+					'controller' => 'Posts',
+					'action' => 'feed',
+					'_ext' => 'atom',
+				],
+			],
+		])->render('');
+
+		$this->assertStringContainsString('href="' . $this->baseUrl . '/posts/feed.atom"', $out);
+		$this->assertStringContainsString('rel="alternate"', $out);
+		$this->assertStringNotContainsString('<controller>', $out);
+		$this->assertStringNotContainsString('<action>', $out);
+	}
+
+	/**
 	 * Text-typed content (the default) does NOT get CDATA-wrapped — the XML
 	 * encoder takes care of escaping. Avoids needless `<![CDATA[plain text]]>`.
 	 */


### PR DESCRIPTION
## Summary

Adds a full `AtomView` class so the plugin can emit Atom 1.0 feeds alongside RSS 2.0. Closes the long-standing "Add AtomView?" TODO. Builds on PR #25 (already merged on master) which restored the `atom:link` rel/type non-clobber and removed the unearned `atom` keyword — the keyword goes back in this PR now that the capability is real.

### What's in the class

- **Default xmlns binding** for the Atom namespace, plus opt-in `xmlns:prefix` declarations for `dc` / `content` / `itunes` (and any custom prefix registered via `setNamespace()` or a top-level `namespace` key). Only prefixes that actually appear in the rendered tree get declared.
- **Friendly shorthands** alongside the full attribute shape. Bare strings work for `link` (defaults to `rel="alternate"`), `author` (becomes `<author><name>...</name></author>`), and `category` (becomes `<category term="..."/>`). Pass an array with `@`-prefixed keys for multiple links per entry, structured authors with `<name>/<email>/<uri>`, or category schemes.
- **RFC 3339 dates.** `time()` accepts `DateTimeInterface`, an int unix timestamp, or any string `DateTime` can parse. Separate `<published>` / `<updated>` per entry is one of Atom's main wins over RSS — both are preserved verbatim.
- **Typed content.** `content` / `summary` / `rights` / `subtitle` accept the full text-construct shape (`@type` + `@` body). HTML content is CDATA-wrapped via the same placeholder pattern `RssView` uses. Plain text is left un-CDATA'd so the output stays clean.
- **Loud failure on unregistered namespaces.** A `prefix:tag` key whose prefix was never registered throws `RuntimeException` (wrapped in Cake's `SerializationFailureException`) rather than emitting a broken namespace decl.
- **MIME / route extension wiring.** Both the plugin bootstrap and the `AtomView` constructor call `MimeType::setMimeTypes('atom', 'application/atom+xml')` so `$response->withType('atom')` resolves and `Router::extensions(['atom'])` maps `.atom` URLs to this view.

### Tests

13 new tests under `tests/TestCase/View/AtomViewTest.php`:

- Date normalization across `DateTimeImmutable` / int / string
- Minimal feed shape (id/title/updated + default namespace binding)
- `link` shorthand vs explicit `@href` arrays vs list of links
- `author` shorthand-vs-structured equivalence
- Multiple `<author>` and `<contributor>` per feed (Atom-only feature)
- HTML content CDATA-wrapped; plain text not
- `category` shorthand + full attribute form including `@scheme`/`@label`
- `<published>` and `<updated>` as distinct entry fields
- Namespace decls only emitted for prefixes actually used
- Unregistered prefix throws via `RuntimeException` unwrapped from `SerializationFailureException`
- Top-level `namespace` key registers custom prefixes
- Content-Type advertised matches the Atom MIME spec
- Constructor wires `withType('atom')` on the response

### Cleanup / docs

- Restored the `atom` composer keyword.
- README rewritten to describe both view classes with a "which to pick" section pointing podcast publishers at RSS, others at Atom, and noting the both-endpoints option.
- Removed the "Add AtomView ?" TODO entry.
- `docs/README.md` linked, new `docs/View/Atom.md` covers field-by-field input shape, shorthands, and worked examples.

phpunit (32/32), phpstan, and phpcs all clean.
